### PR TITLE
New/list workflow options and list workflows

### DIFF
--- a/lib/ripe/cli.rb
+++ b/lib/ripe/cli.rb
@@ -38,7 +38,7 @@ module Ripe
     ##
     # Retrieve ripe version.
 
-    desc 'version', 'Retrieve ripe version'ß
+    desc 'version', 'Retrieve ripe version'
     def version
       puts "ripe version #{Ripe::VERSION}"
     end
@@ -47,7 +47,7 @@ module Ripe
     # List available workflows
     desc 'list', 'List available workflows'
     def list
-      put Library.list_workflows
+      puts Library.list_workflows
     end
 
   end

--- a/lib/ripe/cli.rb
+++ b/lib/ripe/cli.rb
@@ -11,21 +11,29 @@ module Ripe
   class CLI < Thor
 
     desc 'prepare SAMPLES', 'Prepare jobs from template workflow'
+    # Mandatory parameters
     option :workflow, :aliases => '-w', :type => :string, :required => true,
       :desc => 'Workflow to be applied'
+    option :output_prefix, :aliases => '-x', :type => :string, :required => true,
+      :desc => 'Output prefix', :default => '.ripe/'
+   # Optional parameters
     option :config, :aliases => '-c', :type => :string, :required => false,
       :desc => 'Config file for workflows'
     option :options, :aliases => '-o', :type => :string, :required => false,
-      :desc => 'Options', :default => ''
-    option :output_prefix, :aliases => '-x', :type => :string, :required => true,
-      :desc => 'Output prefix', :default => '.ripe/workers'
-
+      :desc => 'Available options in the format opt1=value1,opt2=value2', :default => ''
+    option :list_options, :aliases => '-l', :type => :boolean, :required => false,
+      :desc => 'List workflow available options', :default => false
     ##
     # Prepare samples.
     #
     # @see Ripe::WorkerController
-
     def prepare(*samples)
+
+      if options[:list_options]
+        Helper.print_options(options[:workflow])
+        return
+      end
+      
       abort 'No samples specified.' if samples.length == 0
 
       config = options[:config] ? Helper.parse_config(options[:config]) : {}

--- a/lib/ripe/cli.rb
+++ b/lib/ripe/cli.rb
@@ -38,9 +38,16 @@ module Ripe
     ##
     # Retrieve ripe version.
 
-    desc 'version', 'Retrieve ripe version'
+    desc 'version', 'Retrieve ripe version'ß
     def version
       puts "ripe version #{Ripe::VERSION}"
+    end
+
+    ##
+    # List available workflows
+    desc 'list', 'List available workflows'
+    def list
+      put Library.list_workflows
     end
 
   end

--- a/lib/ripe/cli/helper.rb
+++ b/lib/ripe/cli/helper.rb
@@ -49,8 +49,8 @@ module Ripe
 
       def self.print_options(workflow)
         puts ""
-        puts 'List available options for workflow : ' + workflow
-        puts '-------------------------------------'
+        puts "Available options for workflow : " + workflow
+        puts "-------------------------------------"
         w = WorkerController.new(workflow, [], '')
         s = ""
         w.params.each{|key, value|

--- a/lib/ripe/cli/helper.rb
+++ b/lib/ripe/cli/helper.rb
@@ -47,6 +47,21 @@ module Ripe
         end
       end
 
+      def self.print_options(workflow)
+        puts ""
+        puts 'List available options for workflow : ' + workflow
+        puts '-------------------------------------'
+        w = WorkerController.new(workflow, [], '')
+        s = ""
+        w.params.each{|key, value|
+          if !['wd', 'group_num', 'handle'].include?("#{key}")
+            s += "#{key}, "
+          end
+          }
+        puts s.chop.chop
+        puts ""
+      end
+
     end
 
   end

--- a/lib/ripe/library.rb
+++ b/lib/ripe/library.rb
@@ -48,14 +48,16 @@ module Ripe
         workflows = Array.new
         paths.map do |path|
             directory =  path.concat("/workflows/")
-            puts directory
-            if File.directory?(directory)
-                workflows += Dir.entries(directory).reject {|f| File.directory?(f)}.map{|f| File.basename(f, '.rb')}
+            puts path
+            if File.directory?(directory) 
+                workflows += Dir.entries(directory).select {|f| f.match('.rb')}.reject{|f| f.match('^._')}.map{|f| File.basename(f, '.rb')}
             end
         end
         workflows.uniq!
         if workflows.any?
             workflows = workflows.join("\n")
+        else
+            puts 'No workflow available. Did you forget to set the library path?'
         end
         workflows
       end

--- a/lib/ripe/library.rb
+++ b/lib/ripe/library.rb
@@ -40,6 +40,27 @@ module Ripe
         search.compact.first
       end
 
+      ## 
+      # List the available workflows
+      # 
+      # @return [String] The list of workflows as a string (one per line) or error/info message
+      def list_workflows
+        workflows = Array.new
+        paths.map do |path|
+            directory =  path.concat("/workflows/")
+            puts directory
+            if File.directory?(directory)
+                workflows += Dir.entries(directory).reject {|f| File.directory?(f)}.map{|f| File.basename(f, '.rb')}
+            end
+        end
+        workflows.uniq!
+        if workflows.any?
+            workflows = workflows.join("\n")
+        end
+        workflows
+      end
+      
+    ##
     end
 
   end

--- a/lib/ripe/worker_controller.rb
+++ b/lib/ripe/worker_controller.rb
@@ -35,7 +35,7 @@ module Ripe
       if ![:patch, :force, :depend].include?(@params[:mode].to_sym)
         abort "Invalid mode #{params[:mode]}."
       end
-
+      
       return if samples.length == 0
 
       @worker_id = 0
@@ -47,7 +47,7 @@ module Ripe
       if sample_blocks
         # Split samples into groups of +:group_num+ samples and produce a
         # worker from each of these groups.
-        @workers = sample_blocks.each_slice(params[:group_num].to_i).map do |worker_blocks|
+        @workers = sample_blocks.each_slice(@params[:group_num].to_i).map do |worker_blocks|
           prepare_worker(worker_blocks, output_prefix, @params)
         end
       else
@@ -91,9 +91,11 @@ module Ripe
     # @return [Hash] a +{sample => block}+ hash
 
     def prepare_sample_blocks(samples, callback, params)
-      sample_blocks = samples.map do |sample|
-        block = callback.call(sample, params)
 
+      sample_blocks = samples.map do |sample|
+
+        block = callback.call(sample, params)
+        
         if block
           # No need to prune if callback returns nil
           block = block.prune(params[:mode].to_sym == :force,

--- a/ripe.gemspec
+++ b/ripe.gemspec
@@ -2,7 +2,6 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require_relative 'lib/ripe/version'
-
 Gem::Specification.new do |spec|
   spec.name          = "ripe"
   spec.version       = Ripe::VERSION
@@ -26,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "guard-rspec", "~> 4.5"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 0.4"
 
-# spec.add_runtime_dependency "fileutils", "0.7"
   spec.add_runtime_dependency "liquid", "~> 3.0"
 
   spec.add_runtime_dependency "thor", "~> 0.19"


### PR DESCRIPTION
- Adding the possibility to list the available workflows 
- Adding a possibility to use the argument -l without samples (for example ripe prepare -w star -l) to list the available options that can be set by the user with the -o argument.  No description is provided for the options.